### PR TITLE
解决在较新系统下的编译问题

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -lcrypto
+CFLAGS += -lcrypto -fgnu89-inline
 #LDFLAGS += -lcrypto
 
 gduth3c: main.o auth.o mem_clr.o md5_one.o md5_dgst.o

--- a/src/auth.c
+++ b/src/auth.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <sys/time.h>
 #include <time.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -81,7 +82,7 @@ int auth_init()
     return 0;
 }
 
-void set_socket_timeout(__time_t sec) {
+void set_socket_timeout(time_t sec) {
     struct timeval timeout;
     timeout.tv_sec = sec;
     timeout.tv_usec = 50000;


### PR DESCRIPTION
auth.c

+`#include <sys/time.h>`，解决`storage size of 'timeout' isn't known`

`src/Makefile` CFLAGS 加 `-fgnu89-inline` 解决`inline function 'send_start_logoff' declared but never defined inline int send_start_logoff(int type);`
